### PR TITLE
Add serverless jenkins deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,16 @@
+coverage
+node_modules/
+
+# dotenv environment variables file
+.env
+
+# Serverless directories
+.serverless
+dist
+
+# IntelliJ
 .idea
-node_modules
+*.iml
+
+# Jenkins deployment work directory
+.deployment/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,4 @@
+#!groovy
+@Library('jenkins-jobs') _
+
+serverlessPipeline()

--- a/package.json
+++ b/package.json
@@ -1,11 +1,19 @@
 {
-	"name": "know-god-asset-import",
-	"version": "0.0.1",
-	"dependencies": {
-		"extract-zip": "1.6.7",
-		"tmp": "latest",
-		"request": "^2",
-		"batch": "^0.6.0",
-		"aws-sdk": "^2"
-	}
+  "name": "know-god-asset-import",
+  "version": "0.0.1",
+  "dependencies": {
+    "aws-sdk": "^2",
+    "batch": "^0.6.0",
+    "dotenv": "^6.0.0",
+    "extract-zip": "1.6.7",
+    "lodash": "^4.17.10",
+    "request": "^2",
+    "tmp": "latest"
+  },
+  "devDependencies": {
+    "@cruglobal/serverless-merge-config": "^1.0.1",
+    "serverless": "^1.30.1",
+    "serverless-plugin-existing-s3": "^2.2.2",
+    "serverless-plugin-scripts": "^1.0.2"
+  }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,0 +1,43 @@
+service: know-god-asset-import
+
+custom:
+  scripts:
+    hooks:
+      # Run s3deploy command
+      'aws:deploy:finalize:cleanup': './node_modules/.bin/serverless --stage $ENVIRONMENT s3deploy'
+
+provider:
+  name: aws
+  runtime: nodejs8.10
+  stage: dev
+  region: us-east-1
+  environment: ${file(serverless/environment.js)}
+  iamRoleStatements:
+    - Effect: Allow
+      Action:
+        - "s3:PutBucketNotification"
+      Resource:
+        Fn::Join: ['', ["arn:aws:s3:::", "${env:S3_BUCKET_NAME}"]]
+  $<<: ${file(serverless/provider.js)}
+
+functions:
+  unzip-assets:
+    handler: index.handler
+    events:
+      - existingS3:
+          bucket: ${env:S3_BUCKET_NAME}
+          events:
+            - s3:ObjectCreated:*
+          rules:
+            - prefix: GodTools/
+            - suffix: .zip
+
+package:
+  exclude:
+  - .git/**
+  - .deployment/**
+
+plugins:
+  - '@cruglobal/serverless-merge-config'
+  - serverless-plugin-scripts
+  - serverless-plugin-existing-s3

--- a/serverless/environment.js
+++ b/serverless/environment.js
@@ -1,0 +1,10 @@
+'use strict'
+
+module.exports = () => {
+  // Use dotenv to load local development overrides
+  require('dotenv').config()
+  return {
+    ENVIRONMENT: process.env['ENVIRONMENT'] || 'development',
+    S3_BUCKET_NAME: process.env['S3_BUCKET_NAME'] || 'cru-mobilecontentapi-prod'
+  }
+}

--- a/serverless/provider.js
+++ b/serverless/provider.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const {includes, filter, isEmpty, join} = require('lodash')
+
+module.exports = () => {
+  if (includes(['staging', 'production'], process.env['ENVIRONMENT'])) {
+    // Jenkins / deployment
+    let required = filter(['ECS_CONFIG', 'PROJECT_NAME', 'ENVIRONMENT'], (key) => {
+      return typeof process.env[key] === 'undefined'
+    })
+    if (!isEmpty(required)) {
+      throw new Error('Missing required environment variables (' + join(required, ', ') + ')')
+    }
+    return '${file(${env:ECS_CONFIG}/ecs/${env:PROJECT_NAME}/sls-${env:ENVIRONMENT}.yml):provider}' // eslint-disable-line
+  } else {
+    // local development
+    return {
+      runtime: 'nodejs8.10'
+    }
+  }
+}


### PR DESCRIPTION
This deployment uses https://github.com/matt-filion/serverless-external-s3-event which allows CloudFormation the ability to attach events onto an existing S3 bucket. The plugin requires running s3deploy after the standard serverless deployment, we do this though a plugin hook.