### PR TITLE
Only warn of config errors due to older plugins.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -1,6 +1,6 @@
 service: know-god-asset-import
 frameworkVersion: '3'
-configValidationMode: error
+configValidationMode: warn
 plugins:
   - serverless-plugin-scripts
   - serverless-plugin-existing-s3


### PR DESCRIPTION
> 1 deprecation triggered in the last command:
> CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
>  - S3Deploy for "continue-on-error", "help"
